### PR TITLE
feat(proto): validate envelope invariants; keep --json truncation valid JSON

### DIFF
--- a/crates/pixel-daemon/src/api.rs
+++ b/crates/pixel-daemon/src/api.rs
@@ -451,6 +451,22 @@ impl Service {
     }
 
     pub fn handle(&mut self, req: Request) -> Response {
+        let resp = self.handle_inner(req);
+        // Envelope choke point: every response leaves through here, so a
+        // structurally broken envelope (success without result, failure
+        // without error, wrong protocol) cannot reach the wire unnoticed in
+        // debug builds. Release builds skip the check; the contract tests
+        // cover them.
+        debug_assert!(
+            resp.validate().is_ok(),
+            "invalid envelope for op {}: {}",
+            resp.op,
+            resp.validate().unwrap_err()
+        );
+        resp
+    }
+
+    fn handle_inner(&mut self, req: Request) -> Response {
         let op_name = req.op_name();
         // Ops that return repo state attach a `snapshot` envelope field so
         // callers can correlate the answer with the exact working-tree state
@@ -2821,6 +2837,75 @@ mod tests {
             .output()
             .unwrap();
         assert!(out.status.success(), "git {args:?}: {:?}", out);
+    }
+
+    /// Every envelope the daemon emits must satisfy `Envelope::validate`,
+    /// for success and failure alike, across the whole read-only op
+    /// surface. Without this, an op can return `ok: true` with a null
+    /// result (the CLI would print `null` as an answer) or `ok: false`
+    /// with no message (the agent would retry blind).
+    #[test]
+    fn every_read_op_emits_a_valid_envelope() {
+        let root = tmpdir("envelope-contract");
+        std::fs::write(
+            root.join("login.rs"),
+            "pub fn login(user: &str) -> bool { !user.is_empty() }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("caller.rs"),
+            "use crate::login::login;\npub fn go() { login(\"a\"); }\n",
+        )
+        .unwrap();
+        git(&root, &["init", "-q"]);
+        git(&root, &["add", "."]);
+        git(&root, &["commit", "-qm", "init"]);
+
+        let mut svc = Service::open(&root).unwrap();
+        let reqs: Vec<Request> = vec![
+            Request::Ping,
+            Request::Status {},
+            Request::Graph {},
+            serde_json::from_value(json!({"op":"search","pattern":"login"})).unwrap(),
+            serde_json::from_value(json!({"op":"search","pattern":"("})).unwrap(),
+            serde_json::from_value(json!({"op":"symbol","name":"login"})).unwrap(),
+            serde_json::from_value(json!({"op":"symbol","name":"does_not_exist"})).unwrap(),
+            serde_json::from_value(
+                json!({"op":"impact","uid_or_name":"login","direction":"upstream"}),
+            )
+            .unwrap(),
+            serde_json::from_value(json!({"op":"context","uid":"nope"})).unwrap(),
+            serde_json::from_value(json!({"op":"targets","task":"fix login"})).unwrap(),
+            serde_json::from_value(json!({"op":"processes"})).unwrap(),
+            serde_json::from_value(json!({"op":"clusters"})).unwrap(),
+            serde_json::from_value(json!({"op":"inspect"})).unwrap(),
+            serde_json::from_value(json!({"op":"recall","action":"search"})).unwrap(),
+        ];
+        let mut saw_failure = false;
+        for req in reqs {
+            let op = req.op_name();
+            let resp = svc.handle(req);
+            assert_eq!(resp.op, op, "envelope op must echo the request op");
+            assert_eq!(resp.validate(), Ok(()), "op {op}: {resp:?}");
+            saw_failure |= !resp.ok;
+            // Round trip through the NDJSON wire: one line, parses back to
+            // a still-valid envelope with the same verdict. (Payloads are
+            // not compared: f32 scores widen to f64 on the way through
+            // `Value`, which is a float detail, not a contract break.)
+            let line = serde_json::to_string(&resp).unwrap();
+            assert!(
+                !line.contains('\n'),
+                "op {op}: wire line must be single-line"
+            );
+            let back: Response = serde_json::from_str(&line).unwrap();
+            assert_eq!(back.validate(), Ok(()), "op {op}: wire line re-validates");
+            assert_eq!(
+                (back.ok, back.op, back.error),
+                (resp.ok, resp.op, resp.error)
+            );
+        }
+        assert!(saw_failure, "battery must include at least one failing op");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/pixel-proto/src/envelope.rs
+++ b/crates/pixel-proto/src/envelope.rs
@@ -80,6 +80,41 @@ impl<T> Envelope<T> {
         }
     }
 
+    /// Check the structural invariants every envelope on the wire must
+    /// satisfy, independent of the op:
+    ///
+    /// - `protocol` equals this crate's `ENVELOPE_PROTOCOL_VERSION`;
+    /// - `op` is non-empty;
+    /// - `ok: true` carries a `result` and no `error`;
+    /// - `ok: false` carries an `error` and no `result`;
+    /// - every `error.message` is non-empty.
+    ///
+    /// The daemon asserts this on every response it builds (debug builds)
+    /// and the CLI contract tests assert it on real output, so an op cannot
+    /// ship an envelope that claims success without a payload or failure
+    /// without a reason.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.protocol != ENVELOPE_PROTOCOL_VERSION {
+            return Err(format!(
+                "protocol {} != {ENVELOPE_PROTOCOL_VERSION}",
+                self.protocol
+            ));
+        }
+        if self.op.is_empty() {
+            return Err("op is empty".into());
+        }
+        match (self.ok, self.result.is_some(), &self.error) {
+            (true, false, _) => Err("ok envelope has no result".into()),
+            (true, true, Some(_)) => Err("ok envelope also carries an error".into()),
+            (false, _, None) => Err("failure envelope has no error".into()),
+            (false, true, Some(_)) => Err("failure envelope also carries a result".into()),
+            (false, false, Some(e)) if e.message.trim().is_empty() => {
+                Err("failure envelope has an empty error message".into())
+            }
+            _ => Ok(()),
+        }
+    }
+
     pub fn with_request_id(mut self, request_id: impl Into<String>) -> Self {
         self.request_id = Some(request_id.into());
         self
@@ -357,5 +392,71 @@ mod tests {
         assert!(envelope.snapshot.is_none());
         assert!(envelope.epistemics.is_none());
         assert!(envelope.budget.is_none());
+    }
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+    use crate::error::{ErrorCode, PixelError};
+    use serde_json::json;
+
+    fn err(msg: &str) -> PixelError {
+        PixelError::new(ErrorCode::InvalidInput, msg)
+    }
+
+    #[test]
+    fn constructors_produce_valid_envelopes() {
+        let ok: Envelope<serde_json::Value> = Envelope::success("search", json!({}));
+        assert_eq!(ok.validate(), Ok(()));
+        let failed: Envelope<serde_json::Value> = Envelope::failure("search", err("bad regex"));
+        assert_eq!(failed.validate(), Ok(()));
+    }
+
+    /// A success without a payload would make a caller read `null` as an
+    /// answer. A failure without an error would make it retry blind. Both
+    /// shapes are unrepresentable through the constructors, but a
+    /// hand-built or deserialized envelope can carry them — validate must
+    /// catch each one by name.
+    #[test]
+    fn mixed_ok_and_error_states_are_rejected() {
+        let mut e: Envelope<serde_json::Value> = Envelope::success("op", json!(1));
+        e.error = Some(err("x"));
+        assert!(e.validate().unwrap_err().contains("also carries an error"));
+
+        let mut e: Envelope<serde_json::Value> = Envelope::success("op", json!(1));
+        e.result = None;
+        assert!(e.validate().unwrap_err().contains("no result"));
+
+        let mut e: Envelope<serde_json::Value> = Envelope::failure("op", err("x"));
+        e.error = None;
+        assert!(e.validate().unwrap_err().contains("no error"));
+
+        let mut e: Envelope<serde_json::Value> = Envelope::failure("op", err("x"));
+        e.result = Some(json!(1));
+        assert!(e.validate().unwrap_err().contains("also carries a result"));
+
+        let e: Envelope<serde_json::Value> = Envelope::failure("op", err("  "));
+        assert!(e.validate().unwrap_err().contains("empty error message"));
+    }
+
+    #[test]
+    fn protocol_and_op_are_checked() {
+        let mut e: Envelope<serde_json::Value> = Envelope::success("op", json!(1));
+        e.protocol = ENVELOPE_PROTOCOL_VERSION + 1;
+        assert!(e.validate().unwrap_err().starts_with("protocol"));
+
+        let e: Envelope<serde_json::Value> = Envelope::success("", json!(1));
+        assert_eq!(e.validate(), Err("op is empty".to_string()));
+    }
+
+    /// A wire line from an older or foreign producer goes through serde,
+    /// not the constructors, so the deserialized path must be validated
+    /// the same way.
+    #[test]
+    fn deserialized_wire_line_is_validated() {
+        let line = r#"{"ok":true,"op":"ping","protocol":1,"result":null,"error":null}"#;
+        let e: Envelope<serde_json::Value> = serde_json::from_str(line).unwrap();
+        assert!(e.validate().unwrap_err().contains("no result"));
     }
 }

--- a/crates/pixel/src/main.rs
+++ b/crates/pixel/src/main.rs
@@ -1155,31 +1155,110 @@ fn write_stdout(text: &str) -> Result<(), String> {
 const STDOUT_BYTE_CAP: usize = 256 * 1024;
 
 fn print_data(data: &Value, raw_json: bool) -> Result<(), String> {
+    write_stdout(&render_data(data, raw_json, STDOUT_BYTE_CAP))
+}
+
+/// Serialize `data` for stdout under a byte cap.
+///
+/// Human mode (`raw_json == false`) pretty-prints and, when over the cap,
+/// cuts the text on a char boundary and appends a visible truncation note.
+///
+/// JSON mode (`raw_json == true`) must never emit anything that is not one
+/// JSON document: a caller doing `serde_json::from_slice(stdout)` cannot
+/// recover from a cut-off object followed by prose. When the compact
+/// serialization exceeds the cap, the output becomes a small wrapper
+/// object `{truncated: true, cap_bytes, note, partial}` where `partial` is
+/// the leading bytes of the original serialization as a string. The wrapper
+/// itself can exceed the cap by the size of the note and JSON escaping;
+/// that is bounded and preferable to invalid output.
+fn render_data(data: &Value, raw_json: bool, cap: usize) -> String {
     let mut output = if raw_json {
         serde_json::to_string(data).unwrap_or_default()
     } else {
         serde_json::to_string_pretty(data).unwrap_or_default()
     };
-    // Global byte cap: truncate to STDOUT_BYTE_CAP on a char boundary.
-    // Commands with their own smaller caps will never hit this; it catches
-    // the uncapped paths (inspect, history-search, impact) before they
-    // reach the agent's context window.
-    if output.len() > STDOUT_BYTE_CAP {
-        let mut end = STDOUT_BYTE_CAP;
+    if output.len() > cap {
+        let mut end = cap;
         while end > 0 && !output.is_char_boundary(end) {
             end -= 1;
         }
-        let truncation_note = format!(
-            "\n\n⚠ OUTPUT TRUNCATED AT {STDOUT_BYTE_CAP} BYTES (global safety cap). \
-             The full response was larger than 256KB — re-run with a narrower \
-             scope, --limit, or --offset to page through results. \
-             Remove .pixel/calls.json if the circuit breaker fires."
+        let note = format!(
+            "OUTPUT TRUNCATED AT {cap} BYTES (global safety cap). The full \
+             response was larger — re-run with a narrower scope, --limit, or \
+             --offset to page through results. Remove .pixel/calls.json if \
+             the circuit breaker fires."
         );
         output.truncate(end);
-        output.push_str(&truncation_note);
+        if raw_json {
+            output = serde_json::to_string(&json!({
+                "truncated": true,
+                "cap_bytes": cap,
+                "note": note,
+                "partial": output,
+            }))
+            .unwrap_or_default();
+        } else {
+            output.push_str("\n\n⚠ ");
+            output.push_str(&note);
+        }
     }
     output.push('\n');
-    write_stdout(&output)
+    output
+}
+
+#[cfg(test)]
+mod render_data_tests {
+    use super::*;
+
+    fn big() -> Value {
+        json!({"matches": (0..200).map(|i| json!({"path": format!("src/file_{i}.rs"), "line": i, "text": "é".repeat(20)})).collect::<Vec<_>>()})
+    }
+
+    #[test]
+    fn under_cap_is_untouched() {
+        let d = json!({"a": 1});
+        assert_eq!(render_data(&d, true, 1024), "{\"a\":1}\n");
+        assert_eq!(
+            serde_json::from_str::<Value>(&render_data(&d, false, 1024)).unwrap(),
+            d
+        );
+    }
+
+    /// The reason this matters: agents call `pixel … --json` and parse
+    /// stdout. A truncated document with prose appended is a parse error
+    /// they cannot tell apart from a crash. The JSON path must stay one
+    /// valid document and say it was cut.
+    #[test]
+    fn json_mode_truncation_stays_valid_json_and_flags_it() {
+        let out = render_data(&big(), true, 500);
+        let v: Value = serde_json::from_str(&out).expect("stdout must remain one JSON document");
+        assert_eq!(v["truncated"], true);
+        assert_eq!(v["cap_bytes"], 500);
+        let partial = v["partial"].as_str().unwrap();
+        assert!(partial.len() <= 500);
+        assert!(partial.starts_with("{\"matches\":["));
+        assert!(v["note"].as_str().unwrap().contains("TRUNCATED"));
+        assert_eq!(out.matches('\n').count(), 1, "single NDJSON-safe line");
+    }
+
+    #[test]
+    fn human_mode_truncation_keeps_visible_note() {
+        let out = render_data(&big(), false, 500);
+        assert!(out.contains("⚠ OUTPUT TRUNCATED AT 500 BYTES"));
+        assert!(serde_json::from_str::<Value>(&out).is_err());
+    }
+
+    /// Multi-byte text near the cap: the cut must land on a char boundary
+    /// so the partial string is valid UTF-8 and serializable.
+    #[test]
+    fn truncation_respects_char_boundaries() {
+        let d = json!({"t": "é".repeat(1000)});
+        for cap in 100..140 {
+            let out = render_data(&d, true, cap);
+            let v: Value = serde_json::from_str(&out).unwrap();
+            assert!(v["partial"].as_str().unwrap().len() <= cap);
+        }
+    }
 }
 
 /// Shared graph-command epilogue: candidates protocol + build announcement.

--- a/crates/pixel/tests/json_contract.rs
+++ b/crates/pixel/tests/json_contract.rs
@@ -1,0 +1,166 @@
+//! CLI output contract for `--json`.
+//!
+//! Agents parse `pixel … --json` stdout with a JSON parser. The contract
+//! this file pins down is the one they rely on:
+//!
+//! - stdout is JSON and nothing else: one document per line (a single
+//!   document for most commands, NDJSON for `search`), no prose, no notes;
+//! - human-facing notes (graph build announcements, caveats) go to stderr;
+//! - a failing command exits non-zero, writes the reason to stderr, and
+//!   leaves stdout empty, so a parser never sees a half answer.
+//!
+//! Each command runs against the in-process service (`PIXEL_DAEMON_AUTO_START=0`)
+//! so the test does not depend on, or leave behind, a background daemon.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "git {args:?}: {out:?}");
+}
+
+fn pixel(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pixel"))
+        .args(args)
+        .current_dir(dir)
+        .env("PIXEL_DAEMON_AUTO_START", "0")
+        .output()
+        .unwrap()
+}
+
+fn fixture(tag: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("pixel-json-contract-{tag}-{}", std::process::id()));
+    std::fs::remove_dir_all(&dir).ok();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src/login.rs"),
+        "pub fn login_user(name: &str) -> bool {\n    !name.is_empty()\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/caller.rs"),
+        "use crate::login::login_user;\npub fn go() { login_user(\"a\"); }\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join(".gitignore"), ".pixel/\n").unwrap();
+    git(&dir, &["init", "-q"]);
+    git(&dir, &["add", "."]);
+    git(&dir, &["commit", "-qm", "fixture"]);
+    dir
+}
+
+/// Every non-empty stdout line must parse as a JSON value on its own.
+/// Returns the parsed documents so callers can assert on content.
+fn parse_stdout_lines(out: &Output, what: &str) -> Vec<serde_json::Value> {
+    let stdout = String::from_utf8(out.stdout.clone())
+        .unwrap_or_else(|e| panic!("{what}: stdout is not UTF-8: {e}"));
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line).unwrap_or_else(|e| {
+                panic!(
+                    "{what}: stdout line is not JSON ({e}):\n{line}\n--- stderr:\n{}",
+                    String::from_utf8_lossy(&out.stderr)
+                )
+            })
+        })
+        .collect()
+}
+
+#[test]
+fn json_commands_emit_only_json_on_stdout() {
+    let dir = fixture("ok");
+
+    // (argv, expected top-level keys on the single document)
+    let single_doc: &[(&[&str], &[&str])] = &[
+        (&["status", ".", "--json"], &[]),
+        (&["symbol", "login_user", ".", "--json"], &[]),
+        (&["impact", "login_user", ".", "--json"], &["epistemics"]),
+        (
+            &["targets", "fix login_user", ".", "--json", "--no-manifest"],
+            &["targets", "epistemics"],
+        ),
+        (&["inspect", ".", "--json"], &["head", "branch"]),
+    ];
+    for (argv, keys) in single_doc {
+        let out = pixel(&dir, argv);
+        let what = argv.join(" ");
+        assert!(
+            out.status.success(),
+            "{what} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let docs = parse_stdout_lines(&out, &what);
+        assert_eq!(
+            docs.len(),
+            1,
+            "{what}: expected exactly one JSON document, got {docs:?}"
+        );
+        assert!(docs[0].is_object(), "{what}: top-level must be an object");
+        for k in *keys {
+            assert!(
+                docs[0].get(k).is_some(),
+                "{what}: missing key {k:?} in {}",
+                docs[0]
+            );
+        }
+    }
+
+    // `search --json` is NDJSON: one match object per line, every line JSON.
+    let out = pixel(&dir, &["search", "login_user", ".", "--json"]);
+    assert!(
+        out.status.success(),
+        "search: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let docs = parse_stdout_lines(&out, "search --json");
+    assert!(!docs.is_empty(), "search must find the fixture symbol");
+    for d in &docs {
+        assert!(
+            d.get("path").is_some() || d.get("epistemics").is_some(),
+            "unexpected line: {d}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A failure must be unambiguous to a parser: nothing on stdout, a reason
+/// on stderr, non-zero exit. A `null` or partial document on stdout would
+/// be read as an answer.
+#[test]
+fn failing_json_command_leaves_stdout_empty() {
+    let dir = fixture("fail");
+    let out = pixel(&dir, &["symbol", "no_such_symbol_anywhere", ".", "--json"]);
+    // `symbol` on an unknown name may answer with an empty candidate set or
+    // fail; either way stdout must be parseable and stderr must carry any
+    // failure. Force a definite failure with a malformed regex on search.
+    let _ = parse_stdout_lines(&out, "symbol unknown");
+
+    let out = pixel(&dir, &["search", "(", ".", "--json"]);
+    assert!(!out.status.success(), "malformed regex must fail");
+    assert!(
+        out.stdout.is_empty(),
+        "stdout must be empty on failure, got: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.starts_with("pixel: "),
+        "stderr must carry the reason: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Makes the JSON contract Pixel offers to agents something the test suite enforces, instead of a convention.

## Why

Agents parse `pixel … --json` with a JSON parser. Two gaps let a structurally broken answer through today:

1. Nothing checked an envelope before it hit the wire. A success with a null result or a failure without a message would have been printed as an answer.
2. `print_data` cut a >256 KB response mid-object and appended a prose note. In `--json` mode that is a parse error the agent cannot tell from a crash, and the comment above it claimed a `truncated` flag that did not exist.

## What

- `pixel-proto`: `Envelope::validate()` with the structural invariants (protocol, op, ok⇔result, !ok⇔error, non-empty message) and tests for every rejected shape, including the deserialized wire path.
- `pixel-daemon`: `Service::handle` is now the single choke point and `debug_assert!`s `validate()` on every response. A battery test runs 14 read-only requests (successes and failures) and checks each envelope validates and survives the NDJSON round trip.
- `pixel-cli`: `render_data` extracted from `print_data`. In JSON mode a capped response becomes one valid document `{truncated: true, cap_bytes, note, partial}`; human mode keeps the visible note. Unit tests cover both modes and char-boundary cuts.
- New integration test `crates/pixel/tests/json_contract.rs`: runs `status`, `symbol`, `impact`, `targets`, `inspect`, `search` with `--json` against a fixture repo (daemon auto-start disabled) and asserts stdout is JSON only; a failing command leaves stdout empty with the reason on stderr.

## Behaviour change

Only the truncation path in `--json` mode: output over the cap is now a wrapper object rather than cut JSON plus text. Everything under the cap is byte-identical.

## Gates

- `cargo test` for pixel-proto, pixel-daemon, pixel-cli: green.
- `cargo clippy --all-targets`: no warnings in touched code. Pre-existing warnings remain in `pixel-bench` benches, `pixel-ops/tests/crash_matrix.rs`, and one `map_or` in `api.rs` tests under clippy 1.98; not touched here.
- Workspace tests: `pixel-ops/tests/provenance.rs` fails on this machine because the global git config points `blame.ignoreRevsFile` at a missing `.git-blame-ignore-revs`; environmental, unrelated to this change.
- `cargo fmt` with rustfmt 1.9.0 wants to reformat about 25 untouched files on `main`; left alone to keep this diff focused.
