### PR TITLE
chore(ci): bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test + Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -41,7 +41,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
           - target: aarch64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -66,7 +66,7 @@ jobs:
           shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pixel-${{ matrix.target }}
           path: |
@@ -78,10 +78,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -138,7 +138,7 @@ jobs:
           EOF
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             artifacts/pixel-*.tar.gz


### PR DESCRIPTION
Bumps every pinned action in `.github/workflows/` to its current major. `dtolnay/rust-toolchain@stable` is unchanged (it is a branch alias, not a version).

| Action | Before | After |
| --- | --- | --- |
| actions/checkout | v4 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| softprops/action-gh-release | v2 | v3 |

## Breaking changes reviewed

- All four moved to the Node 24 runtime, which needs runner 2.327.1+. Every job here runs on GitHub-hosted runners, so nothing to do.
- download-artifact v5 changed the extraction path for single downloads by artifact ID. The release job downloads by pattern with `merge-multiple: true`, which the migration guide lists as needing no action.
- download-artifact v8 turns digest mismatches into errors by default and stops unzipping non-zipped payloads. Both are desirable here: artifacts are produced by upload-artifact in the same run.
- action-gh-release v3 is a runtime move only; the `files` and token inputs used here are unchanged.

Not touched: `macos-13` for the x86_64 Apple build. GitHub has been retiring that image; worth a separate look.

Verified on GitHub release pages on 2026-09-04. Not runnable locally; CI on this PR is the check.
