### PR TITLE
chore: apply /claude-api prompt-audit findings to hook text and rule files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,13 @@
 
 ## Reinstall and Reconfig After Each Implementation Turn
 
-After finishing any implementation turn in this repo (code edit + verify cycle), you MUST:
+After finishing any implementation turn in this repo (code edit + verify cycle):
 
 1. **Rebuild and reinstall the pixel binary** so the installed CLI matches the working tree:
    ```bash
    cargo build --release -p pixel-cli && cp target/release/pixel ~/.local/bin/.pixel.tmp.$$ && mv -f ~/.local/bin/.pixel.tmp.$$ ~/.local/bin/pixel
    ```
-   (Atomic rename avoids corrupting the code signature of a running binary on macOS.)
+   (Atomic rename avoids corrupting the code signature of a running binary on macOS — in-place `cp` overwrites a mapped Mach-O, invalidating the ad-hoc signature and causing SIGKILL on next invocation.)
 2. **In parallel** (both only need the new binary, not each other):
    - **Track A:** `pixel index --history .` — rebuild the facts/history index.
    - **Track B:** `build-agent-config && pixel install` — propagate rule edits to tool directories, then reinstall hooks and managed blocks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Reinstall and Reconfig After Each Implementation Turn
 
-After finishing any implementation turn in this repo (code edit + verify cycle), you MUST:
+After finishing any implementation turn in this repo (code edit + verify cycle):
 
 1. **Rebuild and reinstall the pixel binary** so the installed CLI matches the working tree:
    ```bash
@@ -13,3 +13,8 @@ After finishing any implementation turn in this repo (code edit + verify cycle),
    - **Track A:** `pixel index --history .` — rebuild the facts/history index.
    - **Track B:** `build-agent-config && pixel install` — propagate rule edits to tool directories, then reinstall hooks and managed blocks.
 3. **Run `pixel doctor`** and confirm green (or explicitly report any non-green check).
+
+### When to skip
+
+- Pure read-only exploration (no edits to `crates/` or rules).
+- The turn only touched docs, prompts, or bench scripts — nothing that changes binary behavior or installed rules.

--- a/crates/pixel/src/guard.rs
+++ b/crates/pixel/src/guard.rs
@@ -853,7 +853,7 @@ fn retrieval_guard_advisory(_cwd: &Path, idx_root: &Path) -> ! {
         "In an indexed directory, consider running `pixel targets` before searching the codebase."
             .into(),
         format!("  pixel targets \"<one-line task description>\" {root}"),
-        "That returns the P0/P1/P2 file list in <50ms. Work P0 first, then P1.".into(),
+        "That returns the P0/P1/P2 file list.".into(),
         "After scoping, use `pixel search` / `pixel resolve` for code search — not grep/glob."
             .into(),
         "Proceeding with the original retrieval call.".into(),

--- a/crates/pixel/src/post_compaction.rs
+++ b/crates/pixel/src/post_compaction.rs
@@ -154,7 +154,7 @@ fn read_manifest(cwd: &Path) -> Result<Option<String>, String> {
     // Build a compact manifest summary for re-injection.
     let mut lines = Vec::new();
     lines.push(
-        "[PIXEL:POST_COMPACTION] Context was compacted. Your active `pixel targets` manifest has been re-injected below — do NOT read or edit files outside this list. Re-run `pixel targets` if the task has changed.\n"
+        "[PIXEL:POST_COMPACTION] Context was compacted. Your active `pixel targets` manifest is re-injected below; it is the scoped file list for the current task, so work from it and treat files outside it as out of scope unless the task requires them. Re-run `pixel targets` if the task has changed.\n"
             .to_string(),
     );
 

--- a/crates/pixel/src/prompt_submit.rs
+++ b/crates/pixel/src/prompt_submit.rs
@@ -364,8 +364,7 @@ fn emit_boundary(event: &BoundaryEvent, event_name: &str) -> ! {
     let note = format!(
         "[PIXEL:TASK_BOUNDARY] Task boundary detected ({signal}, similarity {sim:.2}). \
          Previous task context: {summary}…\n\
-         Suggest the user run /compact to free up context before proceeding with this new task. \
-         Do NOT attempt a mental reset yourself — let the CLI's real compaction do the work.",
+         Suggest the user run /compact before starting this new task; compaction is what actually frees the context.",
         sim = event.similarity,
         summary = event.context_summary.chars().take(150).collect::<String>(),
     );


### PR DESCRIPTION
## Why

We ran `/claude-api prompt-audit` on this repo. The audit scans every piece of text that reaches the model (rule files, hook-injected context, guard advisories) for patterns written for older, less steerable models: capitalised boosters, prohibitions with no provenance, volatile claims, and duplicated rule files that drift apart. Target model was Claude Fable 5.1, the current Claude Code flagship; the repo makes no Anthropic API calls of its own.

The audit found six items. Five are fixed here; one is out of scope (see below).

## Changes

| File | Finding | Fix |
|---|---|---|
| `crates/pixel/src/post_compaction.rs` | Re-injected text said **do NOT read or edit files outside this list**, but the guard is deliberately advisory because the sniper-discovery bench showed hard scoping collapses recall. Current models follow this literally and lose recall after every compaction. | Reworded as scoped guidance that matches the advisory contract. |
| `crates/pixel/src/prompt_submit.rs` | "Do NOT attempt a mental reset yourself" is a prohibition against a failure the model was not going to make; it anchors toward it. | Positive statement: suggest `/compact`, because compaction is what frees context. |
| `crates/pixel/src/guard.rs` | "in <50ms" is a latency claim nothing re-verifies; "Work P0 first, then P1" is strategy coaching. | Kept only the contract sentence. |
| `CLAUDE.md`, `AGENTS.md` | "you MUST" booster; the two files had drifted (AGENTS.md had a "When to skip" section, CLAUDE.md had the code-signature explanation). | Booster dropped, both files now identical. |

## Not changed

- `crates/pixel-install/src/install.rs` patches the rule text at install time to strip retired `usable-git` framing and a benchmark citation. The fossil lives in the source rule file (`~/.agent-config/rules/pixel.md`, owned by dotfiles), so the fix belongs there; once done, the `replace()` shim can go.
- `SESSION_USAGE` in `pixel-proto` keeps "mandatory" wording; it is product doctrine the doctor checks for consistency. Flagged only.

## Verification

- `cargo clippy -p pixel-cli --all-targets -D warnings`: clean
- `cargo test -p pixel-cli`: 147 passed
- `cargo fmt --check` fails on pre-existing let-chain formatting in untouched regions; it fails identically on `main`.
- Rebuilt and reinstalled the binary, `pixel index --history .` fresh, `pixel install` green. `pixel doctor` shows the same two reds as `main` (`rule.scenarios`, `install.pi-rules`), both caused by the rule file missing on this machine, not by this change.
- Still needs a runtime check: re-run `scripts/pixel-bench.sh` scenario s2-scope before/after to confirm the post-compaction wording does not move recall.
